### PR TITLE
fix: --version shows correct version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sarif-codeclimate",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sarif-codeclimate",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sarif-codeclimate",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Convert your SARIF output into a readable JSON compatible with GitLab Code Climate Tool",
   "main": "out/lib/converter.js",
   "bin": {

--- a/src/bin/sarif-codeclimate.ts
+++ b/src/bin/sarif-codeclimate.ts
@@ -4,12 +4,14 @@ import { Command } from 'commander';
 import { green, red } from 'colors';
 import { writeFileSync } from 'fs';
 import { convert } from '../lib/converter';
+import { version } from '../../package.json';
+
 const program = new Command();
 
 program
   .name('sarif-codeclimate')
   .description('Converts a SARIF file to a Code Climate JSON file')
-  .version('2.0.0')
+  .version(version)
   .requiredOption('-i, --input <path>', 'Path to the SARIF file')
   .option('-o, --output <path>', 'Path to the Code Climate JSON file')
   .action((options) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "./out",
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": true,
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"]


### PR DESCRIPTION
Closes #5 

`--version` argument now uses the version number defined in `package.json`.
No need to sync them manually anymore.


Tested the change like so

```
podman run -it -v .:/repo:z node:latest bash
cd /repo
npm i
npm run test
  Test Suites: 1 passed, 1 total
  Tests:       11 passed, 11 total
  [...]
npm start -- --version
  2.1.2
```
